### PR TITLE
Fix immediate timeouts when specifying a timeout/--connect-timeout

### DIFF
--- a/lib/nettime.d.ts
+++ b/lib/nettime.d.ts
@@ -1,0 +1,49 @@
+declare interface NettimeOptions {
+  url: string;
+  credentials?: NettimeRequestCredentials;
+  method?: string;
+  headers?: object;
+  timeout?: number;
+  rejectUnauthorized?: boolean;
+  requestCount?: number;
+  requestDelay?: number;
+  outputFile?: string;
+  returnResponse?: boolean;
+  includeHeaders?: boolean;
+  appendToOutput?: any;
+  failOnOutputFileError?: boolean;
+  httpVersion?: string;
+  data?: any;
+}
+
+declare interface NettimeRequestCredentials {
+  username: string;
+  password: string;
+}
+
+declare interface NettimeResponse {
+  timings: NettimeTimings;
+  httpVersion: string;
+  statusCode: number;
+  statusMessage: string;
+  headers?: object;
+  response?: Buffer;
+}
+
+declare interface NettimeTimings {
+  socketOpen: number[];
+  dnsLookup: number[];
+  tcpConnection: number[];
+  tlsHandshake: number[];
+  firstByte: number[];
+  contentTransfer: number[];
+  socketClose: number[];
+}
+
+declare function nettime(options: NettimeOptions): Promise<NettimeResponse>;
+declare namespace nettime {
+  export function getDuration (start: number, end: number): number;
+  export function getMilliseconds (timings: number[]): number;
+}
+
+export = nettime

--- a/lib/nettime.js
+++ b/lib/nettime.js
@@ -179,11 +179,6 @@ function makeSingleRequest (options) {
     }
     request.end()
 
-    // Workaround for Node.js 10+.
-    if (timeout) {
-      timeoutHandler = setTimeout(() => request.abort())
-    }
-
     function getParameters () {
       if (typeof options === 'string') {
         const url = options

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "node": ">=8"
   },
   "main": "./lib/nettime.js",
+  "types": "./lib/nettime.d.ts",
   "bin": {
     "nettime": "./bin/nettime"
   },

--- a/tests/nettime.js
+++ b/tests/nettime.js
@@ -39,7 +39,7 @@ function readCertificate (name) {
 }
 
 function serve (request, response) {
-  setTimeout(respond, 2)
+  setTimeout(respond, 5)
 
   function respond () {
     const url = request.url
@@ -289,9 +289,9 @@ test.test('test with a missing web page', test => {
     .then(test.end)
 })
 
-test.test('test timed out connection to an unreachable host', test => {
-  return makeRequest('http', '192.0.2.1', 80, '/', {
-    timeout: 10
+test.test('test response timeout', test => {
+  return makeRequest('http', ipAddress, insecurePort, '', {
+    timeout: 1
   })
     .then(test.fail)
     .catch(error => {


### PR DESCRIPTION
The `setTimeout(...)` that has been removed was cancelling requests
_immediately_ if a timeout was specified (either in code with the `timeout` param or via command line as `--connect-timeout`.

> time nettime --connect-timeout 100000 "https://google.com/"
> Connection timed out.
> 0.16s user 0.02s system 103% cpu 0.178 total

It seems as if the setTimeout was added to appease a failing test,
though the test in question claims to "test timed out connection to an
unreachable host". If connecting to an unreachable host the error thrown
is `EHOSTUNREACH`, not `ETIMEDOUT`. Perhaps this was different in versions
of Node < 10, but considering Node v8 is EOL it seems that the removed
test is the bug and not the implementation..

Soo, I removed the setTimeout, increased the default response time of the mock server and
lowered the timeout of the test. It _seems_ to work; YMMV

I suppose my only problem with this is that its not a __--connect-timeout__ but more like a --total-request-and-response-time timeout but that's just [too hard](https://www.mediawiki.org/wiki/Naming_things).